### PR TITLE
update API endpoints for Feb 2026 Dev Mode changes and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 auth.ini
 .cache-*
 playlists/
+__pycache__/
+requirements.txt

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Examples:
 
 ## Setup
 
-* Create an app on [Spotify My Dashboard](https://developer.spotify.com/dashboard/applications)
-* Redirect URI can be anything (e.g. `http://localhost/`)
+* Create an app on [Spotify My Dashboard](https://developer.spotify.com/dashboard/applications) (requires Spotify Premium since February 11, 2026)
+* Redirect URI can be anything (e.g. `https://127.0.0.1/`)
 * Copy auth.ini.example to auth.ini
 * Insert the client id, token, redirect uri and Spotify username in auth.ini

--- a/spotify-playlists.py
+++ b/spotify-playlists.py
@@ -30,6 +30,9 @@ SCOPES = (
     "playlist-read-collaborative",
     "playlist-read-private",
     "user-library-read",
+    "user-library-modify",
+    "user-follow-read",
+    "user-follow-modify",
     "playlist-modify-private",
     "playlist-modify-public",
 )
@@ -69,7 +72,8 @@ def process_tracks(tracks):
     result = []
 
     for item in tracks["items"]:
-        track = item["track"]
+        # The track object might be nested under "item" (new Web API rules) or "track" (legacy or saved tracks)
+        track = item.get("item") or item.get("track")
 
         if track is None:
             # some playlists have extra "null" tracks (without any information), just skip them
@@ -94,13 +98,20 @@ def write_playlist(name, dirname, tracks, type, location=None, public=False, col
 
     xspf_path = "{}/{}.xspf".format(dirname, name.replace("/", "_"))
 
-    with open(xspf_path, "w") as f:
+    with open(xspf_path, "w", encoding="utf-8") as f:
         f.write(content)
 
 
 def export_playlists(sp, username, dirname):
     if not os.path.isdir(dirname):
         os.mkdir(dirname)
+
+    # Retrieve canonical User ID from Spotify directly to handle cases where
+    # the configured username in auth.ini is an email address or display name.
+    try:
+        current_user_id = sp.current_user()["id"]
+    except Exception:
+        current_user_id = username
 
     playlists = sp.current_user_playlists()
     playlist_items = playlists["items"]
@@ -113,14 +124,27 @@ def export_playlists(sp, username, dirname):
         if playlist is None:
             continue
 
-        tracks = sp.playlist_items(
-            playlist["id"],
-            fields="items(track(name,artists(name),uri)),next",
-        )
-        tracks_processed = process_tracks(tracks)
-        while tracks["next"]:
-            tracks = sp.next(tracks)
-            tracks_processed.extend(process_tracks(tracks))
+        # Spotify API February 2026 update: Playlist contents (items) are only available
+        # for playlists the user owns or collaborates on.
+        is_owner = playlist.get("owner", {}).get("id") == current_user_id
+        is_collaborative = playlist.get("collaborative", False)
+        if not (is_owner or is_collaborative):
+            print(f"Skipping playlist '{playlist['name']}' as the user does not own or collaborate on it.", file=sys.stderr)
+            continue
+
+        try:
+            tracks = sp.playlist_items(
+                playlist["id"],
+                fields="items(item(name,artists(name),uri)),next",
+            )
+            tracks_processed = process_tracks(tracks)
+            while tracks["next"]:
+                tracks = sp.next(tracks)
+                tracks_processed.extend(process_tracks(tracks))
+        except spotipy.SpotifyException as e:
+            print(f"Error fetching tracks for playlist '{playlist['name']}': {e}", file=sys.stderr)
+            continue
+
         write_playlist(
             playlist["name"],
             dirname,
@@ -138,6 +162,87 @@ def export_playlists(sp, username, dirname):
         tracks_processed.extend(process_tracks(tracks))
     write_playlist("Saved tracks", dirname, tracks_processed, type="saved_tracks")
 
+    try:
+        albums = sp.current_user_saved_albums()
+        albums_processed = []
+        while albums:
+            for item in albums["items"]:
+                album = item["album"]
+                if album is None:
+                    continue
+                artists = ";".join([artist["name"] for artist in album["artists"]])
+                albums_processed.append({"title": album["name"], "artists": artists, "uri": album["uri"]})
+            if albums["next"]:
+                albums = sp.next(albums)
+            else:
+                break
+        write_playlist("Saved albums", dirname, albums_processed, type="saved_albums")
+    except spotipy.SpotifyException as e:
+        print(f"Error fetching saved albums: {e}", file=sys.stderr)
+
+    try:
+        artists_processed = []
+        results = sp.current_user_followed_artists(limit=50)
+        while results and "artists" in results:
+            artists_list = results["artists"]["items"]
+            for artist in artists_list:
+                artists_processed.append({
+                    "title": artist["name"],
+                    "artists": artist["name"],
+                    "uri": artist["uri"]
+                })
+            after = results["artists"]["cursors"]["after"]
+            if after:
+                results = sp.current_user_followed_artists(limit=50, after=after)
+            else:
+                break
+        write_playlist("Followed artists", dirname, artists_processed, type="followed_artists")
+    except spotipy.SpotifyException as e:
+        print(f"Error fetching followed artists: {e}", file=sys.stderr)
+
+    try:
+        shows = sp.current_user_saved_shows()
+        shows_processed = []
+        while shows:
+            for item in shows["items"]:
+                show = item["show"]
+                if show is None:
+                    continue
+                shows_processed.append({
+                    "title": show["name"],
+                    "artists": show.get("publisher", ""),
+                    "uri": show["uri"]
+                })
+            if shows["next"]:
+                shows = sp.next(shows)
+            else:
+                break
+        write_playlist("Followed podcasts", dirname, shows_processed, type="followed_podcasts")
+    except spotipy.SpotifyException as e:
+        print(f"Error fetching followed podcasts: {e}", file=sys.stderr)
+
+    try:
+        episodes = sp.current_user_saved_episodes()
+        episodes_processed = []
+        while episodes:
+            for item in episodes["items"]:
+                episode = item["episode"]
+                if episode is None:
+                    continue
+                show_name = episode.get("show", {}).get("name", "")
+                episodes_processed.append({
+                    "title": episode["name"],
+                    "artists": show_name,
+                    "uri": episode["uri"]
+                })
+            if episodes["next"]:
+                episodes = sp.next(episodes)
+            else:
+                break
+        write_playlist("Liked podcasts", dirname, episodes_processed, type="liked_podcasts")
+    except spotipy.SpotifyException as e:
+        print(f"Error fetching liked podcasts: {e}", file=sys.stderr)
+
 
 def import_playlist(sp, username, filename):
     tree = xml.etree.ElementTree.parse(filename)
@@ -147,6 +252,7 @@ def import_playlist(sp, username, filename):
     tracks = []
     public = False
     collaborative = False
+    playlist_type = "playlist"
 
     for elem in root.findall("{http://xspf.org/ns/0/}trackList/{http://xspf.org/ns/0/}track"):
         location = elem.find("{http://xspf.org/ns/0/}location").text
@@ -164,13 +270,39 @@ def import_playlist(sp, username, filename):
         if elem_collaborative is not None:
             collaborative = elem_collaborative.text.lower() == "true"
 
-    playlist_id = sp.user_playlist_create(username, name, public=public)["id"]
-    if collaborative:
-        sp.user_playlist_change_details(username, playlist_id, collaborative=collaborative)
+        elem_type = elem_extension.find("{http://xspf.org/ns/0/}type")
+        if elem_type is not None:
+            playlist_type = elem_type.text
 
-    # the Spotify API allows only 100 tracks per request
-    for tracks_chunk in chunks(tracks, 100):
-        sp.user_playlist_add_tracks(username, playlist_id, tracks_chunk)
+    # docs say limit is 50 but we get an error if more than 40
+    if playlist_type == "saved_tracks":
+        # Save tracks directly to user's library in chunks of 40 (API limit)
+        for tracks_chunk in chunks(tracks, 40):
+            sp.current_user_saved_tracks_add(tracks_chunk)
+    elif playlist_type == "saved_albums":
+        # Save albums directly to user's library in chunks of 40 (API limit)
+        for albums_chunk in chunks(tracks, 40):
+            sp.current_user_saved_albums_add(albums_chunk)
+    elif playlist_type == "followed_artists":
+        # Follow artists directly in chunks of 40 (API limit)
+        for artists_chunk in chunks(tracks, 40):
+            sp.user_follow_artists(artists_chunk)
+    elif playlist_type == "followed_podcasts":
+        # Follow podcast shows directly to user's library in chunks of 40 (API limit)
+        for shows_chunk in chunks(tracks, 40):
+            sp.current_user_saved_shows_add(shows_chunk)
+    elif playlist_type == "liked_podcasts":
+        # Save episodes directly to user's library in chunks of 40 (API limit)
+        for episodes_chunk in chunks(tracks, 40):
+            sp.current_user_saved_episodes_add(episodes_chunk)
+    else:
+        # Use current_user_playlist_create instead of deprecated user_playlist_create
+        # which used the removed POST /users/{user_id}/playlists endpoint.
+        playlist_id = sp.current_user_playlist_create(name, public=public, collaborative=collaborative)["id"]
+
+        # the Spotify API allows only 100 tracks per request
+        for tracks_chunk in chunks(tracks, 100):
+            sp.playlist_add_items(playlist_id, tracks_chunk)
 
 
 def main():


### PR DESCRIPTION
### Overview
This Pull Request updates `spotify-playlists.py` to adapt to the Spotify Developer Access and Platform Security changes announced in February 2026. Legacy/deprecated routes that have been removed are replaced with their modern counterparts, response field parsing is aligned with renamed structures, and robustness is improved to prevent crashes during batch operations. 

In addition, this PR expands the utility of the script by adding full export and import support for **Saved Albums**, **Followed Artists**, and **Podcasts (Shows & Saved Episodes)**.

The code was enhanced using Google® Gemini® service, quickly glanced over and tested with followed podcasts, saved podcast episodes, own playlist and liked tracks.

---

### Detailed Changes

#### 1. Compatibility with February 2026 Web API Changes
* **Deprecated Endpoints & Methods**:
  * Replaced `sp.user_playlist_create` with the recommended `sp.current_user_playlist_create` (uses POST `/me/playlists` under the hood, as POST `/users/{user_id}/playlists` was completely removed).
  * Removed the redundant/deprecated `sp.user_playlist_change_details` in favor of setting `collaborative` directly during playlist creation.
  * Replaced `sp.user_playlist_add_tracks` with `sp.playlist_add_items` (uses the updated POST `/playlists/{id}/items` route instead of the removed `/tracks` endpoint).
* **Playlist Field Renaming**:
  * Refactored `process_tracks` to parse both `"item"` (new Web API rules) and `"track"` (legacy/saved tracks fallback) keys: `track = item.get("item") or item.get("track")`.
  * Updated the query filter inside `sp.playlist_items` from `items(track(...))` to `items(item(...))` to match the renamed playlist response fields.
* **Access Safeguards**:
  * Under updated Dev Mode rules, playlist tracks can only be fetched for playlists that the current user owns or collaborates on. Added verification checks (`is_owner` or `is_collaborative`) before calling `sp.playlist_items`.
  * Wrapped tracks fetching inside a robust `try...except spotipy.SpotifyException` block. If there's an issue fetching a specific playlist, the script logs a warning and proceeds with the rest of the export rather than crashing.

#### 2. Saved Albums, Followed Artists, and Podcasts Support (Export/Import)
* **New Scopes**: Added `"user-library-modify"`, `"user-follow-read"`, and `"user-follow-modify"` to authorization scopes.
* **Export Expansion**:
  * **Saved Albums**: Fetched via `sp.current_user_saved_albums()` and written to `Saved albums.xspf` (type: `"saved_albums"`).
  * **Followed Artists**: Fetched via cursor-paginated `sp.current_user_followed_artists()` and written to `Followed artists.xspf` (type: `"followed_artists"`).
  * **Followed Podcasts (Shows)**: Fetched via `sp.current_user_saved_shows()` and written to `Followed podcasts.xspf` (type: `"followed_podcasts"`).
  * **Liked Podcasts (Saved Episodes)**: Fetched via `sp.current_user_saved_episodes()` and written to `Liked podcasts.xspf` (type: `"liked_podcasts"`).
* **Import Expansion**:
  * Added parsing of the `<type>` element from the XML `<extension>` tag.
  * Added direct routing back into the user's library in batch-sized chunks of 40 (to stay within API limits):
    * `"saved_tracks"` -> `sp.current_user_saved_tracks_add()`
    * `"saved_albums"` -> `sp.current_user_saved_albums_add()`
    * `"followed_artists"` -> `sp.user_follow_artists()`
    * `"followed_podcasts"` -> `sp.current_user_saved_shows_add()`
    * `"liked_podcasts"` -> `sp.current_user_saved_episodes_add()`

#### 3. Platform Encoding Fixes
* Added `encoding="utf-8"` explicitly in `write_playlist()` to prevent `UnicodeEncodeError` when dealing with tracks containing UTF-8 characters on Windows platforms.

### References

[Update on Developer Access and Platform Security](https://developer.spotify.com/blog/2026-02-06-update-on-developer-access-and-platform-security)
[February 2026 Web API Dev Mode Changes - Migration Guide ](https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide)